### PR TITLE
Use env variables

### DIFF
--- a/config.py
+++ b/config.py
@@ -7,12 +7,15 @@ class Config:
   DOMAIN = ""
 
   def __init__(self):
+    # check to see if this was passed in as an environment variable first
     user = os.getenv("REDSHIFT_USER")
 
+    # fall back to .env file
     if(user is None):
       load_dotenv(find_dotenv())
       user = os.environ.get("REDSHIFT_USER")
 
+    # couldn't find a REDSHIFT_USER, fail
     if(user is None):
       raise Exception("REDSHIFT_USER not found")
 

--- a/config.py
+++ b/config.py
@@ -1,0 +1,19 @@
+import os
+from dotenv import load_dotenv, find_dotenv
+
+class Config:
+  REDSHIFT_USER = ""
+  REDSHIFT_PW = ""
+  DOMAIN = ""
+
+  def __init__(self):
+    user = os.getenv("REDSHIFT_USER")
+
+    if(user is None):
+      load_dotenv(find_dotenv())
+      user = os.environ.get("REDSHIFT_USER")
+
+    if(user is None):
+      raise Exception("REDSHIFT_USER not found")
+
+    self.REDSHIFT_USER = user

--- a/hello-world.py
+++ b/hello-world.py
@@ -1,3 +1,8 @@
+# import os
 import redshift_connector
+from config import Config
+
+CONFIG = Config()
 
 print("Hello World")
+print(CONFIG.REDSHIFT_USER)

--- a/poetry.lock
+++ b/poetry.lock
@@ -136,6 +136,17 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 six = ">=1.5"
 
 [[package]]
+name = "python-dotenv"
+version = "0.20.0"
+description = "Read key-value pairs from a .env file and set them as environment variables"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[package.extras]
+cli = ["click (>=5.0)"]
+
+[[package]]
 name = "pytz"
 version = "2021.3"
 description = "World timezone definitions, modern and historical"
@@ -238,8 +249,8 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.10"
-content-hash = "77534fb32b61facde245f841105dbdebc8fc61e185f78d8dfd5e3dac1cb344d6"
+python-versions = "^3.9"
+content-hash = "45a798aeda04b46c10cf9345342ceb761f8daf270ee57c6e677d68258bfe96f0"
 
 [metadata.files]
 asn1crypto = [
@@ -348,6 +359,10 @@ pyparsing = [
 python-dateutil = [
     {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
     {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
+]
+python-dotenv = [
+    {file = "python-dotenv-0.20.0.tar.gz", hash = "sha256:b7e3b04a59693c42c36f9ab1cc2acc46fa5df8c78e178fc33a8d4cd05c8d498f"},
+    {file = "python_dotenv-0.20.0-py3-none-any.whl", hash = "sha256:d92a187be61fe482e4fd675b6d52200e7be63a12b724abbf931a40ce4fa92938"},
 ]
 pytz = [
     {file = "pytz-2021.3-py2.py3-none-any.whl", hash = "sha256:3672058bc3453457b622aab7a1c3bfd5ab0bdae451512f6cf25f64ed37f5b87c"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ authors = ["Code.org"]
 [tool.poetry.dependencies]
 python = "^3.9"
 redshift-connector = "^2.0.905"
+python-dotenv = "^0.20.0"
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
Creating a config object that will allow us to set various environment variables. Will look at variables passed in via the command line (on script execution) first then fall back to a local `.env` file (<-- this will come in handy with local dev environments). At the moment, this just looks for a user, but we can expand upon this. If it can't find a user, it fails with an error.